### PR TITLE
docs(README): Add semantic release rule to create release on docs change

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,8 @@ module.exports = {
   "plugins": [
       ["@semantic-release/commit-analyzer", {
           "releaseRules": [
-              {"type": "chore", "scope": "deps", "release": "patch"}
+              { "type": "chore", "scope": "deps", "release": "patch" },
+              { "type": "docs", "scope": "README", "release": "patch" },
           ]
       }],
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Added rule to semantic release to trigger docs update on NPM when `README.md` is changed.
This PR does not change`README.md` but has to do release for https://github.com/phrase/ngx-translate-phraseapp/pull/48