### PR TITLE
Fix: npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Enable Corepack and Yarn 1.22.19
         run: |
@@ -52,7 +51,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Enable Corepack and Yarn 1.22.19
         run: |

--- a/release.config.js
+++ b/release.config.js
@@ -11,7 +11,7 @@ module.exports = {
       [
         "@semantic-release/exec",
         {
-            prepareCmd: "npm version ${nextRelease.version} --no-git-tag-version",
+            prepareCmd: "npm version ${nextRelease.version} --no-git-tag-version && yarn build",
             publishCmd: "npm publish ./dist --registry=https://registry.npmjs.org/ --provenance"
         }
       ],


### PR DESCRIPTION
Fix release issue: https://github.com/phrase/ngx-translate-phraseapp/actions/runs/23489681618/job/68354292135
- double-checked npm: everything looks correct there, so trying some adjustments in the repo:
- First bump, then build: try to make dist match the version we need
- Remove registry-url when installing node, for OIDC it is not needed and might lead to auth issue
  - permission id-token stays `write`, this is needed