### PR TITLE
chore: bump node version in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
 
       - name: Enable Corepack and Yarn 1.22.19
         run: |
@@ -50,7 +51,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
 
       - name: Enable Corepack and Yarn 1.22.19
         run: |


### PR DESCRIPTION
Failing CI details:
```
Run actions/setup-node@v6
  with:
    node-version: 22
Environment details
  node: v22.22.1 // too old ‼️
  npm: 10.9.4 // too old ‼️
  yarn: 1.22.22
```
- older Node/npm combinations do not perform OIDC-based publish
- bumped node version to match working example https://github.com/phrase/i18next-phrase-in-context-editor-post-processor/commits/master/
  - node 24 is bundled with npm 11.x which meets requirement for trusted publishing
  - proof in working repo's release: https://github.com/phrase/i18next-phrase-in-context-editor-post-processor/actions/runs/23437766584/job/68180158035