### PR TITLE
chore: adjust release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/phrase/ngx-translate-phraseapp.git"
+    "url": "git+https://github.com/phrase/ngx-translate-phraseapp.git"
   },
   "bugs": {
     "url": "https://github.com/phrase/ngx-translate-phraseapp/issues",

--- a/release.config.js
+++ b/release.config.js
@@ -12,7 +12,7 @@ module.exports = {
         "@semantic-release/exec",
         {
             prepareCmd: "npm version ${nextRelease.version} --no-git-tag-version && yarn build",
-            publishCmd: "npm publish ./dist --registry=https://registry.npmjs.org/ --provenance"
+            publishCmd: "npm publish ./dist --registry=https://registry.npmjs.org/"
         }
       ],
       "@semantic-release/github",


### PR DESCRIPTION
- Fix warning:
```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish Removed invalid "scripts"
npm WARN publish "repository.url" was normalized to "git+https://github.com/phrase/ngx-translate-phraseapp.git"
```
- remove redundant `--provenance` flag